### PR TITLE
Fix compiler options.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -69,4 +69,5 @@ endif()
 
 if(NOT TARGET sdf)
    add_library(sdf ${SOURCES})
+   set_target_properties(sdf PROPERTIES COMPILE_FLAGS "-mcmodel=medium")
 endif()


### PR DESCRIPTION
PGI doesn't allow '-mcmodel=medium' and '-fpic' to be applied together.
EOS and castmat need '-fpic' so that SDF_extension will build, but
everything else needs '-mcmodel=medium'.